### PR TITLE
fix: Fix the type of the method that raises the exception

### DIFF
--- a/lib/rbs/trace/method_tracing.rb
+++ b/lib/rbs/trace/method_tracing.rb
@@ -32,7 +32,7 @@ module RBS
 
       # @rbs () -> TracePoint
       def trace
-        @trace ||= TracePoint.new(:call, :return, :raise) { |tp| record(tp) }
+        @trace ||= TracePoint.new(:call, :return) { |tp| record(tp) }
       end
 
       # @rbs () -> Logger
@@ -75,7 +75,7 @@ module RBS
         case tp.event
         when :call
           call_event(tp)
-        when :return, :raise
+        when :return
           return_event(tp, definition)
         end
       rescue StandardError => e
@@ -110,7 +110,7 @@ module RBS
         # TODO: check usecase where decl is nil
         return unless decl
 
-        decl.return_type = tp.event == :return ? [obj_to_class(tp.return_value)] : [NilClass]
+        decl.return_type = [obj_to_class(tp.return_value)]
         definition.decls << decl
       end
 

--- a/spec/rbs/trace/method_tracing_spec.rb
+++ b/spec/rbs/trace/method_tracing_spec.rb
@@ -112,6 +112,28 @@ RSpec.describe RBS::Trace::MethodTracing do
     expect(definition.rbs).to eq("() -> void")
   end
 
+  it "supports methods that call methods that raise exceptions" do # rubocop:disable RSpec/ExampleLength
+    source = <<~RUBY
+      class A
+        def m(x)
+          foo
+        end
+
+        def foo
+          raise "error"
+        end
+      end
+    RUBY
+    file = trace_source(source, mod) do
+      mod::A.new.m(1)
+    rescue StandardError
+      nil
+    end
+
+    def_m = file.definitions["#{mod}::A#m"]
+    expect(def_m.rbs).to eq("(Integer) -> void")
+  end
+
   it "supports singleton methods" do
     source = <<~RUBY
       class A


### PR DESCRIPTION
There is no need to trace the `raise` event because the `return` event
occurs when raising exceptions.

Since argument information is managed on a stack, tracing two events
will cause argument mismatches.
