### PR TITLE
perf: Calculate target file paths first

### DIFF
--- a/sig/generated/rbs/trace.rbs
+++ b/sig/generated/rbs/trace.rbs
@@ -11,12 +11,6 @@ module RBS
     # steep:ignore:end
     RUBY_LIB_PATH: String
 
-    PATH_INTERNAL: String
-
-    PATH_EVAL: String
-
-    PATH_INLINE_TEMPLATE: String
-
     # @rbs (?log_level: Symbol, ?raises: bool) -> void
     def initialize: (?log_level: Symbol, ?raises: bool) -> void
 
@@ -57,9 +51,6 @@ module RBS
 
     # @rbs (TracePoint, AST::Members::MethodDefinition) -> void
     def return_event: (TracePoint, AST::Members::MethodDefinition) -> void
-
-    # @rbs (String) -> bool
-    def ignore_path?: (String) -> bool
 
     # @rbs (String, Symbol) -> bool
     def void_return_type?: (String, Symbol) -> bool

--- a/spec/rbs/trace/file_spec.rb
+++ b/spec/rbs/trace/file_spec.rb
@@ -151,6 +151,7 @@ RSpec.describe RBS::Trace::File do
       RUBY
       load(path.to_s, mod)
 
+      trace = RBS::Trace.new(log_level: :debug, raises: true)
       trace.enable { mod::A.new.m }
       file = trace.files[path.to_s]
 

--- a/spec/support/trace_helper.rb
+++ b/spec/support/trace_helper.rb
@@ -5,7 +5,7 @@ require "tempfile"
 module TraceHelper
   # @rbs (String) { (Module) -> void } -> void
   def load_source(source)
-    tf = Tempfile.open(["", ".rb"]) do |fp|
+    tf = Tempfile.open(["", ".rb"], "tmp") do |fp|
       fp.write(source)
       fp
     end


### PR DESCRIPTION
Because it is faster to call `Set#include?` than to call
`String#start_with?` for each trace.
