### PR TITLE
Make InlineCommentVisitor support nested modules defined with w/ ::

### DIFF
--- a/lib/rbs/trace/inline_comment_visitor.rb
+++ b/lib/rbs/trace/inline_comment_visitor.rb
@@ -15,17 +15,17 @@ module RBS
       # @rbs override
       # @rbs (Prism::Node) -> void
       def visit_class_node(node)
-        @context.push(node.name)
-        super
-        @context.pop
+        with_context node do
+          super
+        end
       end
 
       # @rbs override
       # @rbs (Prism::Node) -> void
       def visit_module_node(node)
-        @context.push(node.name)
-        super
-        @context.pop
+        with_context node do
+          super
+        end
       end
 
       # @rbs override
@@ -56,6 +56,17 @@ module RBS
 
         decl.members.find do |member|
           member.is_a?(AST::Members::MethodDefinition) && member.name == name
+        end
+      end
+
+      def with_context(node)
+        names = node.constant_path.full_name_parts
+        @context.push(*names)
+
+        yield
+
+        names.each do
+          @context.pop
         end
       end
     end

--- a/lib/rbs/trace/inline_comment_visitor.rb
+++ b/lib/rbs/trace/inline_comment_visitor.rb
@@ -59,6 +59,7 @@ module RBS
         end
       end
 
+      # @rbs (Prism::ModuleNode | Prism::ClassNode) { () -> void } -> void
       def with_context(node)
         names = node.constant_path.full_name_parts
         @context.push(*names)

--- a/lib/rbs/trace/inline_comment_visitor.rb
+++ b/lib/rbs/trace/inline_comment_visitor.rb
@@ -66,9 +66,7 @@ module RBS
 
         yield
 
-        names.each do
-          @context.pop
-        end
+        @context.pop(names.size)
       end
     end
   end

--- a/lib/rbs/trace/inline_comment_visitor.rb
+++ b/lib/rbs/trace/inline_comment_visitor.rb
@@ -61,7 +61,10 @@ module RBS
 
       # @rbs (Prism::ModuleNode | Prism::ClassNode) { () -> void } -> void
       def with_context(node)
-        names = node.constant_path.full_name_parts
+        constant_path = node.constant_path
+        raise if constant_path.is_a?(Prism::MissingNode) || constant_path.is_a?(Prism::CallNode)
+
+        names = constant_path.full_name_parts
         @context.push(*names)
 
         yield

--- a/sig/generated/rbs/trace/inline_comment_visitor.rbs
+++ b/sig/generated/rbs/trace/inline_comment_visitor.rbs
@@ -22,6 +22,9 @@ module RBS
 
       # @rbs (Symbol) -> AST::Members::MethodDefinition?
       def find_method_definition: (Symbol) -> AST::Members::MethodDefinition?
+
+      # @rbs (Prism::ModuleNode | Prism::ClassNode) { () -> void } -> void
+      def with_context: (Prism::ModuleNode | Prism::ClassNode) { () -> void } -> void
     end
   end
 end


### PR DESCRIPTION
For these modules (like `module A::B::C`), `visit_{class,module}_node` will be called only once, and `node.name` returns only the base name of the module (`C`). Because of that, there were missing signature comments in cases like the test `it "inline signatures will be written for methods in nested modules defined w/ ::"` I added.
This change fixes that problem by making the visitor recognize the full path of such kinds of modules.