### PR TITLE
feat: Support inline comments using colon-prefixed RBS syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,25 @@ end
 RBS::Trace.new(paths: Dir.glob("#{Dir.pwd}/app/models/**/*.rb"))
 ```
 
+### Change the format of embedded comments
+
+You can change the comment format.
+
+| `comment_format` | embedded comment |
+|---|---|
+| `:rbs_keyword` (default) | `# @rbs () -> void` |
+| `:rbs_colon` | `#: () -> void` |
+
+```ruby
+trace.save_comments(:rbs_colon)
+```
+
+or
+
+```bash
+$ rbs-trace inline --rb-dir=app --rb-dir=lib --comment-format=rbs_colon
+```
+
 ### Save RBS declarations as files
 
 ```ruby

--- a/lib/rbs/trace.rb
+++ b/lib/rbs/trace.rb
@@ -50,10 +50,10 @@ module RBS
       @files ||= {}
     end
 
-    # @rbs () -> void
-    def save_comments
+    # @rbs (?Symbol) -> void
+    def save_comments(comment_format = nil)
       files.each do |path, file|
-        file.rewrite if @paths.include?(path)
+        file.rewrite(comment_format) if @paths.include?(path)
       end
     end
 

--- a/lib/rbs/trace/cli/inline.rb
+++ b/lib/rbs/trace/cli/inline.rb
@@ -5,7 +5,7 @@ module RBS
     class CLI
       class Inline
         BANNER = <<~USAGE
-          Usage: rbs-trace inline --sig-dir=DIR --rb-dir=DIR
+          Usage: rbs-trace inline --sig-dir=DIR --rb-dir=DIR --comment-format=FORMAT
 
           Insert RBS inline comments from RBS files.
 
@@ -14,16 +14,19 @@ module RBS
             $ rbs-trace inline --sig-dir=sig --rb-dir=app
 
           Options:
+            --comment-format FORMAT: Format for comments (`rbs_keyword` or `rbs_colon`, default: `rbs_keyword`)
         USAGE
 
         # @rbs (Array[String]) -> void
         def run(args) # rubocop:disable Metrics
           sig_dir = Pathname.pwd.join("sig").to_s
           rb_dirs = [] #: Array[String]
+          comment_format = :rbs_keyword
 
           opts = OptionParser.new(BANNER)
           opts.on("--sig-dir DIR") { |dir| sig_dir = dir }
           opts.on("--rb-dir DIR") { |dir| rb_dirs << dir }
+          opts.on("--comment-format FORMAT") { |format| comment_format = format.to_sym }
           opts.parse!(args)
 
           if rb_dirs.empty?
@@ -35,7 +38,7 @@ module RBS
             rb_files = rb_dirs.flat_map { |rb_dir| Dir.glob("#{rb_dir}/**/*.rb") }
             rb_files.each do |path|
               file = File.new(path, decls)
-              file.rewrite
+              file.rewrite(comment_format)
             end
           end
         end

--- a/lib/rbs/trace/file.rb
+++ b/lib/rbs/trace/file.rb
@@ -27,11 +27,11 @@ module RBS
         end
       end
 
-      # @rbs () -> String
-      def with_rbs
+      # @rbs (?Symbol?) -> String
+      def with_rbs(comment_format = nil)
         result = Prism.parse_file(@path)
         comments = {} #: Hash[Integer, String]
-        result.value.accept(InlineCommentVisitor.new(@decls, comments))
+        result.value.accept(InlineCommentVisitor.new(@decls, comments, comment_format))
 
         lines = result.source.source.lines
         comments.keys.sort.reverse_each do |i|
@@ -42,9 +42,9 @@ module RBS
         lines.join
       end
 
-      # @rbs () -> void
-      def rewrite
-        ::File.write(@path, with_rbs)
+      # @rbs (?Symbol?) -> void
+      def rewrite(comment_format = nil)
+        ::File.write(@path, with_rbs(comment_format))
       end
 
       # @rbs () -> String

--- a/lib/rbs/trace/inline_comment_visitor.rb
+++ b/lib/rbs/trace/inline_comment_visitor.rb
@@ -3,10 +3,11 @@
 module RBS
   class Trace
     class InlineCommentVisitor < Prism::Visitor
-      # @rbs (Hash[TypeName, AST::Declarations::t], Hash[Integer, String]) -> void
-      def initialize(decls, comments)
+      # @rbs (Hash[TypeName, AST::Declarations::t], Hash[Integer, String], Symbol?) -> void
+      def initialize(decls, comments, comment_format)
         @decls = decls
         @comments = comments
+        @comment_prefix = comment_format == :rbs_colon ? "#:" : "# @rbs"
         @context = [] #: Array[Symbol]
 
         super()
@@ -38,7 +39,7 @@ module RBS
           overloads = OverloadCompact.new(member.overloads).call
           comment = overloads.map(&:method_type).join(" | ")
 
-          @comments[lineno] = "#{indent}# @rbs #{comment}\n"
+          @comments[lineno] = "#{indent}#{@comment_prefix} #{comment}\n"
         end
 
         super

--- a/sig/generated/rbs/trace.rbs
+++ b/sig/generated/rbs/trace.rbs
@@ -23,8 +23,8 @@ module RBS
     # @rbs () -> Hash[String, File]
     def files: () -> Hash[String, File]
 
-    # @rbs () -> void
-    def save_comments: () -> void
+    # @rbs (?Symbol) -> void
+    def save_comments: (?Symbol) -> void
 
     # @rbs (out_dir: String) -> void
     def save_files: (out_dir: String) -> void

--- a/sig/generated/rbs/trace/file.rbs
+++ b/sig/generated/rbs/trace/file.rbs
@@ -11,11 +11,11 @@ module RBS
       # @rbs (untyped, Class, Symbol) -> AST::Members::MethodDefinition?
       def find_or_new_method_definition: (untyped, Class, Symbol) -> AST::Members::MethodDefinition?
 
-      # @rbs () -> String
-      def with_rbs: () -> String
+      # @rbs (?Symbol?) -> String
+      def with_rbs: (?Symbol?) -> String
 
-      # @rbs () -> void
-      def rewrite: () -> void
+      # @rbs (?Symbol?) -> void
+      def rewrite: (?Symbol?) -> void
 
       # @rbs () -> String
       def to_rbs: () -> String

--- a/sig/generated/rbs/trace/inline_comment_visitor.rbs
+++ b/sig/generated/rbs/trace/inline_comment_visitor.rbs
@@ -3,8 +3,8 @@
 module RBS
   class Trace
     class InlineCommentVisitor < Prism::Visitor
-      # @rbs (Hash[TypeName, AST::Declarations::t], Hash[Integer, String]) -> void
-      def initialize: (Hash[TypeName, AST::Declarations::t], Hash[Integer, String]) -> void
+      # @rbs (Hash[TypeName, AST::Declarations::t], Hash[Integer, String], Symbol?) -> void
+      def initialize: (Hash[TypeName, AST::Declarations::t], Hash[Integer, String], Symbol?) -> void
 
       # @rbs override
       # @rbs (Prism::Node) -> void

--- a/spec/rbs/trace/cli/inline_spec.rb
+++ b/spec/rbs/trace/cli/inline_spec.rb
@@ -47,6 +47,78 @@ RSpec.describe RBS::Trace::CLI::Inline do
       end
     end
 
+    context "when `--comment-format` is specified (rbs_keyword)" do
+      it "embeds RBS into Ruby code" do
+        Dir.mktmpdir do |dir|
+          Dir.chdir(dir) do
+            base = Pathname.pwd
+            rb_dir = base.join("app").tap(&:mkdir)
+            sig_dir = base.join("sig").tap(&:mkdir)
+
+            rb_dir.join("a.rb").write(<<~RUBY)
+              class A
+                def foo
+                  puts "foo"
+                end
+              end
+            RUBY
+            sig_dir.join("a.rbs").write(<<~RBS)
+              class A
+                def foo: () -> void
+              end
+            RBS
+
+            cli.run(["inline", "--rb-dir", "app", "--comment-format", "rbs_keyword"])
+
+            expect(rb_dir.join("a.rb").read).to eq(<<~RUBY)
+              class A
+                # @rbs () -> void
+                def foo
+                  puts "foo"
+                end
+              end
+            RUBY
+          end
+        end
+      end
+    end
+
+    context "when `--comment-format` is specified (rbs_colon)" do
+      it "embeds RBS into Ruby code" do
+        Dir.mktmpdir do |dir|
+          Dir.chdir(dir) do
+            base = Pathname.pwd
+            rb_dir = base.join("app").tap(&:mkdir)
+            sig_dir = base.join("sig").tap(&:mkdir)
+
+            rb_dir.join("a.rb").write(<<~RUBY)
+              class A
+                def foo
+                  puts "foo"
+                end
+              end
+            RUBY
+            sig_dir.join("a.rbs").write(<<~RBS)
+              class A
+                def foo: () -> void
+              end
+            RBS
+
+            cli.run(["inline", "--rb-dir", "app", "--comment-format", "rbs_colon"])
+
+            expect(rb_dir.join("a.rb").read).to eq(<<~RUBY)
+              class A
+                #: () -> void
+                def foo
+                  puts "foo"
+                end
+              end
+            RUBY
+          end
+        end
+      end
+    end
+
     context "when `--sig-dir` is not specified" do
       it "embeds RBS into Ruby code" do
         Dir.mktmpdir do |dir|

--- a/spec/rbs/trace/file_spec.rb
+++ b/spec/rbs/trace/file_spec.rb
@@ -27,6 +27,48 @@ RSpec.describe RBS::Trace::File do
       end
     end
 
+    it "supports rbs_keyword comment format" do
+      source = <<~RUBY
+        class A
+          def m
+          end
+        end
+      RUBY
+      load_source(source) do |mod|
+        trace.enable { mod::A.new.m }
+        file = trace.files.values.first
+
+        expect(file.with_rbs(:rbs_keyword)).to eq(<<~RUBY)
+          class A
+            # @rbs () -> nil
+            def m
+            end
+          end
+        RUBY
+      end
+    end
+
+    it "supports rbs_colon comment format" do
+      source = <<~RUBY
+        class A
+          def m
+          end
+        end
+      RUBY
+      load_source(source) do |mod|
+        trace.enable { mod::A.new.m }
+        file = trace.files.values.first
+
+        expect(file.with_rbs(:rbs_colon)).to eq(<<~RUBY)
+          class A
+            #: () -> nil
+            def m
+            end
+          end
+        RUBY
+      end
+    end
+
     it "does not insert a comment if there is a `@rbs` comment" do
       source = <<~RUBY
         class A

--- a/spec/rbs/trace_spec.rb
+++ b/spec/rbs/trace_spec.rb
@@ -3,9 +3,9 @@
 RSpec.describe RBS::Trace do
   let(:trace) { described_class.new(log_level: :debug, raises: true) }
 
-  # @rbs (RBS::Trace) -> String
-  def to_rbs(trace)
-    trace.files.each_value.map(&:with_rbs).join
+  # @rbs (RBS::Trace, ?Symbol) -> String
+  def to_rbs(trace, comment_format = nil)
+    trace.files.each_value.map { |file| file.with_rbs(comment_format) }.join
   end
 
   describe "#enable" do
@@ -22,6 +22,22 @@ RSpec.describe RBS::Trace do
         expect(to_rbs(trace)).to eq(<<~RUBY)
           class A
             # @rbs () -> nil
+            def m
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_keyword)).to eq(<<~RUBY)
+          class A
+            # @rbs () -> nil
+            def m
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_colon)).to eq(<<~RUBY)
+          class A
+            #: () -> nil
             def m
             end
           end
@@ -46,6 +62,22 @@ RSpec.describe RBS::Trace do
             end
           end
         RUBY
+
+        expect(to_rbs(trace, :rbs_keyword)).to eq(<<~RUBY)
+          class A
+            # @rbs (Integer) -> nil
+            def m(x)
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_colon)).to eq(<<~RUBY)
+          class A
+            #: (Integer) -> nil
+            def m(x)
+            end
+          end
+        RUBY
       end
     end
 
@@ -62,6 +94,22 @@ RSpec.describe RBS::Trace do
         expect(to_rbs(trace)).to eq(<<~RUBY)
           class A
             # @rbs (?Integer) -> nil
+            def m(x = 1)
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_keyword)).to eq(<<~RUBY)
+          class A
+            # @rbs (?Integer) -> nil
+            def m(x = 1)
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_colon)).to eq(<<~RUBY)
+          class A
+            #: (?Integer) -> nil
             def m(x = 1)
             end
           end
@@ -86,6 +134,22 @@ RSpec.describe RBS::Trace do
             end
           end
         RUBY
+
+        expect(to_rbs(trace, :rbs_keyword)).to eq(<<~RUBY)
+          class A
+            # @rbs (*Integer) -> nil
+            def m(*x)
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_colon)).to eq(<<~RUBY)
+          class A
+            #: (*Integer) -> nil
+            def m(*x)
+            end
+          end
+        RUBY
       end
     end
 
@@ -102,6 +166,22 @@ RSpec.describe RBS::Trace do
         expect(to_rbs(trace)).to eq(<<~RUBY)
           class A
             # @rbs (x: Integer) -> nil
+            def m(x:)
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_keyword)).to eq(<<~RUBY)
+          class A
+            # @rbs (x: Integer) -> nil
+            def m(x:)
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_colon)).to eq(<<~RUBY)
+          class A
+            #: (x: Integer) -> nil
             def m(x:)
             end
           end
@@ -126,6 +206,22 @@ RSpec.describe RBS::Trace do
             end
           end
         RUBY
+
+        expect(to_rbs(trace, :rbs_keyword)).to eq(<<~RUBY)
+          class A
+            # @rbs (?x: Integer) -> nil
+            def m(x: 0)
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_colon)).to eq(<<~RUBY)
+          class A
+            #: (?x: Integer) -> nil
+            def m(x: 0)
+            end
+          end
+        RUBY
       end
     end
 
@@ -142,6 +238,22 @@ RSpec.describe RBS::Trace do
         expect(to_rbs(trace)).to eq(<<~RUBY)
           class A
             # @rbs (**Integer) -> nil
+            def m(**opts)
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_keyword)).to eq(<<~RUBY)
+          class A
+            # @rbs (**Integer) -> nil
+            def m(**opts)
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_colon)).to eq(<<~RUBY)
+          class A
+            #: (**Integer) -> nil
             def m(**opts)
             end
           end
@@ -167,6 +279,24 @@ RSpec.describe RBS::Trace do
         expect(to_rbs(trace)).to eq(<<~RUBY)
           class A
             # @rbs () -> nil
+            def m
+              raise "error"
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_keyword)).to eq(<<~RUBY)
+          class A
+            # @rbs () -> nil
+            def m
+              raise "error"
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_colon)).to eq(<<~RUBY)
+          class A
+            #: () -> nil
             def m
               raise "error"
             end
@@ -207,6 +337,34 @@ RSpec.describe RBS::Trace do
             end
           end
         RUBY
+
+        expect(to_rbs(trace, :rbs_keyword)).to eq(<<~RUBY)
+          class A
+            # @rbs (Integer) -> nil
+            def m(x)
+              foo
+            end
+
+            # @rbs () -> nil
+            def foo
+              raise "error"
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_colon)).to eq(<<~RUBY)
+          class A
+            #: (Integer) -> nil
+            def m(x)
+              foo
+            end
+
+            #: () -> nil
+            def foo
+              raise "error"
+            end
+          end
+        RUBY
       end
     end
 
@@ -223,6 +381,22 @@ RSpec.describe RBS::Trace do
         expect(to_rbs(trace)).to eq(<<~RUBY)
           class A
             # @rbs () -> nil
+            def self.m
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_keyword)).to eq(<<~RUBY)
+          class A
+            # @rbs () -> nil
+            def self.m
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_colon)).to eq(<<~RUBY)
+          class A
+            #: () -> nil
             def self.m
             end
           end
@@ -248,6 +422,22 @@ RSpec.describe RBS::Trace do
         expect(to_rbs(trace)).to eq(<<~RUBY)
           class A
             # @rbs (Integer | String) -> nil
+            def m(x)
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_keyword)).to eq(<<~RUBY)
+          class A
+            # @rbs (Integer | String) -> nil
+            def m(x)
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_colon)).to eq(<<~RUBY)
+          class A
+            #: (Integer | String) -> nil
             def m(x)
             end
           end
@@ -278,6 +468,24 @@ RSpec.describe RBS::Trace do
             end
           end
         RUBY
+
+        expect(to_rbs(trace, :rbs_keyword)).to eq(<<~RUBY)
+          class A
+            # @rbs (bool) -> (Integer | String)
+            def m(is_int)
+              is_int ? 1 : "a"
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_colon)).to eq(<<~RUBY)
+          class A
+            #: (bool) -> (Integer | String)
+            def m(is_int)
+              is_int ? 1 : "a"
+            end
+          end
+        RUBY
       end
     end
 
@@ -302,6 +510,22 @@ RSpec.describe RBS::Trace do
             end
           end
         RUBY
+
+        expect(to_rbs(trace, :rbs_keyword)).to eq(<<~RUBY)
+          class A
+            # @rbs (Integer?) -> nil
+            def m(x)
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_colon)).to eq(<<~RUBY)
+          class A
+            #: (Integer?) -> nil
+            def m(x)
+            end
+          end
+        RUBY
       end
     end
 
@@ -318,6 +542,22 @@ RSpec.describe RBS::Trace do
         expect(to_rbs(trace)).to eq(<<~RUBY)
           class A
             # @rbs (nil) -> nil
+            def m(x)
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_keyword)).to eq(<<~RUBY)
+          class A
+            # @rbs (nil) -> nil
+            def m(x)
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_colon)).to eq(<<~RUBY)
+          class A
+            #: (nil) -> nil
             def m(x)
             end
           end
@@ -355,6 +595,22 @@ RSpec.describe RBS::Trace do
             end
           end
         RUBY
+
+        expect(to_rbs(trace, :rbs_keyword)).to eq(<<~RUBY)
+          class A
+            # @rbs (*untyped, **untyped) -> nil
+            def m(*, **, &)
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_colon)).to eq(<<~RUBY)
+          class A
+            #: (*untyped, **untyped) -> nil
+            def m(*, **, &)
+            end
+          end
+        RUBY
       end
     end
 
@@ -371,6 +627,22 @@ RSpec.describe RBS::Trace do
         expect(to_rbs(trace)).to eq(<<~RUBY)
           class A
             # @rbs (Array[untyped], Hash[untyped, untyped], Range[untyped]) -> nil
+            def m(x, y, z)
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_keyword)).to eq(<<~RUBY)
+          class A
+            # @rbs (Array[untyped], Hash[untyped, untyped], Range[untyped]) -> nil
+            def m(x, y, z)
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_colon)).to eq(<<~RUBY)
+          class A
+            #: (Array[untyped], Hash[untyped, untyped], Range[untyped]) -> nil
             def m(x, y, z)
             end
           end
@@ -399,6 +671,24 @@ RSpec.describe RBS::Trace do
             end
           end
         RUBY
+
+        expect(to_rbs(trace, :rbs_keyword)).to eq(<<~RUBY)
+          class A < BasicObject
+            # @rbs (#{mod}::A) -> #{mod}::A
+            def m(x)
+              A.new
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_colon)).to eq(<<~RUBY)
+          class A < BasicObject
+            #: (#{mod}::A) -> #{mod}::A
+            def m(x)
+              A.new
+            end
+          end
+        RUBY
       end
     end
 
@@ -421,10 +711,26 @@ RSpec.describe RBS::Trace do
             end
           end
         RUBY
+
+        expect(to_rbs(trace, :rbs_keyword)).to eq(<<~RUBY)
+          class A
+            # @rbs () -> void
+            def m
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_colon)).to eq(<<~RUBY)
+          class A
+            #: () -> void
+            def m
+            end
+          end
+        RUBY
       end
     end
 
-    it "supports multiple nested modules in a single file" do
+    it "supports multiple nested modules in a single file" do # rubocop:disable RSpec/ExampleLength
       # also defining `class B::C` to check sanity of the stack operations
       source = <<~RUBY
         module A
@@ -458,6 +764,38 @@ RSpec.describe RBS::Trace do
             end
           end
         RUBY
+
+        expect(to_rbs(trace, :rbs_keyword)).to eq(<<~RUBY)
+          module A
+            module B
+            end
+
+            class B::C
+              def m = 'a'
+            end
+
+            class D
+              # @rbs () -> Integer
+              def n = 1
+            end
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_colon)).to eq(<<~RUBY)
+          module A
+            module B
+            end
+
+            class B::C
+              def m = 'a'
+            end
+
+            class D
+              #: () -> Integer
+              def n = 1
+            end
+          end
+        RUBY
       end
     end
 
@@ -483,6 +821,30 @@ RSpec.describe RBS::Trace do
 
           class A::B::C
             # @rbs () -> Integer
+            def m = 1
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_keyword)).to eq(<<~RUBY)
+          module A
+            module B
+            end
+          end
+
+          class A::B::C
+            # @rbs () -> Integer
+            def m = 1
+          end
+        RUBY
+
+        expect(to_rbs(trace, :rbs_colon)).to eq(<<~RUBY)
+          module A
+            module B
+            end
+          end
+
+          class A::B::C
+            #: () -> Integer
             def m = 1
           end
         RUBY


### PR DESCRIPTION
This PR will support comment output in `#: ` format so that RBS::Trace can be used in Sorbet projects. (Maybe even TypeProf?)

## Issue

Sorbet supports comments in RBS format on an experimental basis.
- https://sorbet.org/docs/rbs-support

However, the current latest version (v0.5.12060) does not support the ` @rbs ` syntax, even though it supports comments beginning with `#: `.

The `ok1` and `ok2` methods are type-aware and report type errors, but the `ng` method is untyped and does not report type errors

![screen](https://github.com/user-attachments/assets/be7c34e3-f6f9-4542-8b25-629b35479525)

## Solution

Pass the option “comment_format” to change the prefix of the embedded comment.

| `comment_format` | embedded comment |
|---|---|
| `:rbs_keyword` (default) | `# @rbs () -> void` |
| `:rbs_colon` | `#: () -> void` |

```ruby
trace.save_comments
trace.save_comments(:rbs_keyword)
trace.save_comments(:rbs_colon)
```

```bash
$ rbs-trace inline --rb-dir=app --rb-dir=lib
$ rbs-trace inline --rb-dir=app --rb-dir=lib --comment-format=rbs_keyword
$ rbs-trace inline --rb-dir=app --rb-dir=lib --comment-format=rbs_colon
```

I wrote the code with as little impact on existing usage as possible in mind.