### PR TITLE
feat: Add support for generics other than Array, Range, and Hash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in rbs-trace.gemspec
 gemspec
 
+gem "csv"
 gem "rake"
 gem "rbs-inline", require: false
 gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 7.2)
+  csv
   rake
   rbs-inline
   rbs-trace!

--- a/README.md
+++ b/README.md
@@ -139,6 +139,20 @@ $ rbs-trace inline --rb-dir=app --rb-dir=lib --comment-format=rbs_colon
 trace.save_files(out_dir: "sig/trace/")
 ```
 
+### Specify generics size
+
+By default, generics are applied to the generated results only in the following classes.
+
+- Array
+- Hash
+- Range
+
+If any other classes require generics, configure them as follows.
+
+```ruby
+trace.add_generics_size!("CSV::Table" => 1, "ActiveSupport::HashWithIndifferentAccess" => 2)
+```
+
 ### Parallel testing
 
 If you are using a parallel testing gem such as [parallel_tests](https://github.com/grosser/parallel_tests) or [flatware](https://github.com/briandunn/flatware), first save the type definitions in RBS files.

--- a/lib/rbs/trace.rb
+++ b/lib/rbs/trace.rb
@@ -62,6 +62,11 @@ module RBS
       files.each_value { |file| file.save_rbs(out_dir) }
     end
 
+    # @rbs (Hash[String, Integer]) -> Hash[String, Integer]
+    def add_generics_size!(additional_generics_size)
+      builder.generics_size.merge!(additional_generics_size)
+    end
+
     private
 
     # @rbs () -> Array[String]

--- a/lib/rbs/trace/builder.rb
+++ b/lib/rbs/trace/builder.rb
@@ -9,12 +9,12 @@ module RBS
       UNBOUND_NAME_METHOD = Class.instance_method(:name)
       private_constant :UNBOUND_CLASS_METHOD, :UNBOUND_NAME_METHOD
 
-      GENERICS_SIZE = {
-        Array => 1,
-        Range => 1,
-        Hash => 2
+      DEFAULT_GENERICS_SIZE = {
+        "Array" => 1,
+        "Range" => 1,
+        "Hash" => 2
       }.freeze
-      private_constant :GENERICS_SIZE
+      private_constant :DEFAULT_GENERICS_SIZE
 
       # @rbs (bind: Binding, parameters: Array[__todo__], void: bool) -> Array[__todo__]
       def method_call(bind:, parameters:, void:)
@@ -35,6 +35,11 @@ module RBS
         method_type = method_type.update(type: new_type) # rubocop:disable Style/RedundantSelfAssignment
 
         AST::Members::MethodDefinition::Overload.new(method_type:, annotations: [])
+      end
+
+      # @rbs () -> Hash[String, Integer]
+      def generics_size
+        @generics_size ||= DEFAULT_GENERICS_SIZE.dup
       end
 
       private
@@ -115,7 +120,7 @@ module RBS
         elsif klass == Object || class_name.nil?
           type_untyped
         else
-          size = GENERICS_SIZE[klass].to_i
+          size = generics_size[klass.name].to_i
           args = Array.new(size) { type_untyped }
           Types::ClassInstance.new(name: TypeName.parse(class_name), args:, location: nil)
         end

--- a/sig/generated/rbs/trace.rbs
+++ b/sig/generated/rbs/trace.rbs
@@ -29,6 +29,9 @@ module RBS
     # @rbs (out_dir: String) -> void
     def save_files: (out_dir: String) -> void
 
+    # @rbs (Hash[String, Integer]) -> Hash[String, Integer]
+    def add_generics_size!: (Hash[String, Integer]) -> Hash[String, Integer]
+
     private
 
     # @rbs () -> Array[String]

--- a/sig/generated/rbs/trace/builder.rbs
+++ b/sig/generated/rbs/trace/builder.rbs
@@ -9,13 +9,16 @@ module RBS
 
       UNBOUND_NAME_METHOD: untyped
 
-      GENERICS_SIZE: untyped
+      DEFAULT_GENERICS_SIZE: Hash[String, Integer]
 
       # @rbs (bind: Binding, parameters: Array[__todo__], void: bool) -> Array[__todo__]
       def method_call: (bind: Binding, parameters: Array[__todo__], void: bool) -> Array[__todo__]
 
       # @rbs (__todo__) -> AST::Members::MethodDefinition::Overload
       def method_return: (__todo__) -> AST::Members::MethodDefinition::Overload
+
+      # @rbs () -> Hash[String, Integer]
+      def generics_size: () -> Hash[String, Integer]
 
       private
 


### PR DESCRIPTION
fixed https://github.com/sinsoku/rbs-trace/issues/21

- To avoid increasing dependencies, changed the key for `RBS::Trace::Builder::GENERICS_SIZE` from a class constant to the class name string and renamed it to `RBS::Trace::Builder::DEFAULT_GENERICS_SIZE`
- Added `RBS::Trace#add_generics_size!` so users don't have to manually replace rbs-trace output
  - Ideally, the generic size could be determined from the type definition, but even if possible, it would require significant modification.
  - At the least, allowing users to configure it would be an improvement over the current situation where manual replacement is required.
  - Adding `CSV::Table` or `ActiveSupport::HashWithIndifferentAccess` to `DEFAULT_GENERICS_SIZE` would be endless, so it remains unchanged for now.